### PR TITLE
Remove doubled-up "request method"-path on actions tab

### DIFF
--- a/__tests__/swagger-to-actions.test.ts
+++ b/__tests__/swagger-to-actions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { requestToFunctionName } from "../pages/api/swagger-to-actions";
+import {
+  replaceMarkdownLinks,
+  requestToFunctionName,
+} from "../pages/api/swagger-to-actions";
 
 describe("request to function name", () => {
   it("list organizations", () => {
@@ -33,5 +36,23 @@ describe("request to function name", () => {
       "/api/organizations/{parent_lookup_organization_id}/plugins/activity/"
     );
     expect(fnName).toEqual("get_plugin_activity");
+  });
+});
+
+describe("replaceMarkdownLinks", () => {
+  it("undefined passes through", () => {
+    let result = replaceMarkdownLinks(undefined);
+    expect(result).toEqual(undefined);
+  });
+  it("replace 1 markdown link", () => {
+    let testString = "there's [something](https://something.com)";
+    let result = replaceMarkdownLinks(testString);
+    expect(result).toEqual("there's something");
+  });
+  it("replace 2 markdown links", () => {
+    let testString =
+      "there's [something](https://something.com) [here](https://something.com)";
+    let result = replaceMarkdownLinks(testString);
+    expect(result).toEqual("there's something here");
   });
 });

--- a/components/actions/actionsSection.tsx
+++ b/components/actions/actionsSection.tsx
@@ -386,9 +386,14 @@ function ActionsSection(props: {
                   >
                     {action.name}
                   </h3>
-                  <p className="mt-1 truncate max-h-20 text-sm text-gray-500 whitespace-pre-line">
-                    {action.description}
-                  </p>
+                  {action.description !==
+                    `${action.request_method?.toUpperCase()} ${
+                      action.path
+                    }` && (
+                    <p className="mt-1 truncate max-h-20 text-sm text-gray-500 whitespace-pre-line">
+                      {action.description}
+                    </p>
+                  )}
                 </div>
                 <FlyoutMenu
                   getClassName={(open: boolean) =>

--- a/components/actions/editActionGroupModal.tsx
+++ b/components/actions/editActionGroupModal.tsx
@@ -1,30 +1,13 @@
-import { Dialog, Listbox, Transition } from "@headlessui/react";
+import { Dialog } from "@headlessui/react";
 import {
-  ArchiveBoxIcon,
-  ArrowRightCircleIcon,
-  ChevronDownIcon,
-  DocumentDuplicateIcon,
-  HeartIcon,
-  TrashIcon,
-  UserPlusIcon,
-  GlobeAltIcon,
-  CodeBracketSquareIcon,
-  CursorArrowRippleIcon,
-} from "@heroicons/react/20/solid";
-import {
-  LinkIcon,
   PencilSquareIcon,
   QuestionMarkCircleIcon,
 } from "@heroicons/react/24/outline";
-import { XMarkIcon } from "@heroicons/react/24/solid";
-import React, { Fragment, useRef, useState } from "react";
+import React, { useRef } from "react";
 import { classNames } from "../../lib/utils";
 import FloatingLabelInput from "../floatingLabelInput";
-import { Database } from "../../lib/database.types";
 import Modal from "../modal";
-import { Action, ActionGroup, ActionGroupJoinActions } from "../../lib/types";
-import { SelectBoxOption } from "../selectBox";
-import SelectBox from "../selectBox";
+import { ActionGroup } from "../../lib/types";
 
 export default function EditActionGroupModal(props: {
   actionGroup: ActionGroup;

--- a/components/actions/editActionModal.tsx
+++ b/components/actions/editActionModal.tsx
@@ -214,13 +214,13 @@ export default function EditActionModal(props: {
 
       <div className="mt-10 mb-4 grid grid-cols-2 gap-x-6">
         <div className="relative">
-          <div className="absolute top-3 right-3 z-10">
-            <QuestionMarkCircleIcon className="peer h-6 w-6 text-gray-400 hover:text-gray-500 transition rounded-full hover:bg-gray-50" />
-            <div className={classNames("-top-8 left-12 w-64 popup")}>
-              The AI uses this to write this 1-click reply - be descriptive.
-              E.g.
-            </div>
-          </div>
+          {/*<div className="absolute top-3 right-3 z-10">*/}
+          {/*  <QuestionMarkCircleIcon className="peer h-6 w-6 text-gray-400 hover:text-gray-500 transition rounded-full hover:bg-gray-50" />*/}
+          {/*  <div className={classNames("-top-8 left-12 w-64 popup")}>*/}
+          {/*    The AI uses this to write this 1-click reply - be descriptive.*/}
+          {/*    E.g.*/}
+          {/*  </div>*/}
+          {/*</div>*/}
           <FloatingLabelInput
             className={classNames(
               "px-4 text-gray-900 border-gray-200 border focus:border-sky-500 focus:ring-sky-500 focus:ring-1 ",
@@ -297,12 +297,9 @@ export default function EditActionModal(props: {
         )}
         <div className="absolute top-3 right-3">
           <QuestionMarkCircleIcon className="peer h-6 w-6 text-gray-400 hover:text-gray-500 transition rounded-full" />
-          <div className={classNames("right-0 -top-36 w-64 popup")}>
-            Give instructions & information to the AI writing the reply.
-            <br />
-            <br />
-            E.g. &ldquo;Book a call, my calendar link is:
-            https://calendly.com/...&rdquo;
+          <div className={classNames("right-0 -top-20 w-64 popup")}>
+            Information given to the AI about what this action does. E.g.
+            &#34;Sends a message to the user.&#34;
           </div>
         </div>
         <div

--- a/components/actions/editActionModal.tsx
+++ b/components/actions/editActionModal.tsx
@@ -34,7 +34,7 @@ interface JsonTextBoxProps {
 function JsonTextBox(props: JsonTextBoxProps) {
   return (
     <>
-      <div className="w-full px-32 flex flex-row justify-between place-items-start overflow-hidden">
+      <div className="w-full px-20 flex flex-row justify-between place-items-start overflow-hidden">
         <div className="font-bold text-lg text-gray-100 mt-4 w-40">
           {props.title.charAt(0).toUpperCase() +
             props.title.slice(1).replace(/_/g, " ")}
@@ -319,7 +319,7 @@ export default function EditActionModal(props: {
 
       <div className="my-4 flex flex-col gap-y-4">
         {/* PATH */}
-        <div className="w-full px-32 flex flex-row justify-center place-items-center">
+        <div className="w-full px-20 flex flex-row justify-center place-items-center">
           <div className="font-bold text-lg text-gray-100 w-40">Path:</div>
           <div className="w-full flex-1">
             <input
@@ -345,7 +345,7 @@ export default function EditActionModal(props: {
           </div>
         </div>
         {/* METHOD */}
-        <div className="w-full px-32 flex flex-row justify-center place-items-center">
+        <div className="w-full px-20 flex flex-row justify-center place-items-center">
           <div className="font-bold text-lg text-gray-100 w-40">Method:</div>
           <SelectBox
             options={allRequestMethods}

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -61,12 +61,12 @@ export default function Playground() {
             <h2 className="text-gray-200 font-medium">User description</h2>
             <p className="text-gray-400 text-sm">
               With each API request, you can provide a description of the user
-              who is asking the question and instructions on how to address
-              them.
+              who is asking the question, any useful information for accessing
+              your API (e.g. user id) and instructions on how to address them.
             </p>
             <textarea
               className="mt-4 w-full h-96 bg-gray-700 border border-gray-600 rounded-md focus:border-purple-700 focus:ring-purple-700 placeholder:text-gray-400 text-gray-200 px-3 py-2 text-sm resize-none"
-              placeholder="E.g. Bill is a salesperson at Acme Corp. He's not comfortable with statistical terms, instead use plain English to answer his questions."
+              placeholder="E.g. Bill is a salesperson at Acme Corp. His project id is f35ahe2g1p. He's not comfortable with statistical terms, instead use plain English to answer his questions."
               value={userDescription}
               onChange={(e) => setUserDescription(e.target.value)}
               onBlur={() => {

--- a/lib/prompts/prompt.ts
+++ b/lib/prompts/prompt.ts
@@ -39,7 +39,6 @@ export default function getMessages(
     i++;
     numberedActions += `1. navigateTo: This will navigate you to another page. This enables you to use functions that are available on that page. Available pages (in format "- 'page-name': description") are: ${availablePages}. PARAMETERS: - pageName (string): The name of the page you want to navigate to. REQUIRED\n`;
   }
-  // console.log("currentPage.actions", currentPage);
   currentPage.actions.forEach((action) => {
     let paramString = "";
     // For parameters
@@ -69,6 +68,8 @@ export default function getMessages(
       const required = action.request_body_contents["application/json"].schema
         .required as string[];
       Object.entries(properties).forEach(([key, value]) => {
+        // Throw out readonly attributes
+        if (value.readOnly) return;
         const enums = value.enum;
         // TODO: Deal with very long enums better - right now we are just ignoring them
         paramString += `\n- ${key} (${value.type}${

--- a/pages/api/swagger-to-actions.ts
+++ b/pages/api/swagger-to-actions.ts
@@ -133,11 +133,9 @@ export default async function handler(
         }
         groupNameToId[groupName] = actionGroupId;
       }
-      let description = methodObj.operationId
-        ? methodObj.description ??
-          methodObj.summary ??
-          method.toUpperCase() + " " + path
-        : methodObj.description ?? methodObj.summary ?? "";
+      let description =
+        replaceMarkdownLinks(methodObj.description ?? methodObj.summary) ??
+        method.toUpperCase() + " " + path;
       actionInserts.push({
         name:
           methodObj.operationId?.toLowerCase().replaceAll(" ", "_") ??
@@ -238,4 +236,15 @@ export function requestToFunctionName(
   functionName = functionName.replaceAll("__", "_").toLowerCase();
 
   return functionName;
+}
+
+export function replaceMarkdownLinks(
+  inputString: string | undefined
+): string | undefined {
+  if (!inputString) return undefined;
+  const markdownLinkRegEx = /\[([^\]]+)\]\(([^)]+)\)/g;
+  return inputString.replaceAll(
+    markdownLinkRegEx,
+    (match, linkText) => linkText
+  );
 }


### PR DESCRIPTION
3 minor changes:
1. Removed old tooltips on actions edit modal
2. Removed doubling up of method-path when no description in openapi spec
3. Removed markdown links from descriptions in `swagger-to-actions`
4. Also removed `readonly` properties from prompts
5. Improve action edit modal placeholder text and description