### PR TITLE
Reformat function messages from readable in db to low-token in GPT messages

### DIFF
--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -20,14 +20,23 @@ export async function getActiveActionTagsAndActions(
 }
 
 export function DBChatMessageToGPT(message: DBChatMessage): ChatGPTMessage {
-  if (message.role === "function")
-    return {
-      role: message.role,
+  if (message.role === "function") {
+    let content: string;
+    try {
       // Below conversion to JSON and back to string remove all newlines, indentation etc
       // which are empty tokens. This can cut tokens by ~half
-      content: JSON.stringify(JSON.parse(message.content)),
+      content = JSON.stringify(JSON.parse(message.content));
+    } catch (e) {
+      // If invalid JSON
+      content = message.content;
+    }
+
+    return {
+      role: message.role,
+      content: content,
       name: message.name!,
     };
+  }
   return {
     role: message.role as "user" | "assistant",
     content: message.content,

--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -23,7 +23,9 @@ export function DBChatMessageToGPT(message: DBChatMessage): ChatGPTMessage {
   if (message.role === "function")
     return {
       role: message.role,
-      content: message.content,
+      // Below conversion to JSON and back to string remove all newlines, indentation etc
+      // which are empty tokens. This can cut tokens by ~half
+      content: JSON.stringify(JSON.parse(message.content)),
       name: message.name!,
     };
   return {

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -242,6 +242,7 @@ export default async function handler(req: NextRequest) {
         .from("chat_messages")
         .select()
         .eq("conversation_id", requestData.conversation_id)
+        .eq("org_id", org.id)
         .order("conversation_index", { ascending: true });
       if (convResp.error) throw new Error(convResp.error.message);
       const conversation = convResp.data.map(DBChatMessageToGPT);

--- a/pages/api/v1/confirm.ts
+++ b/pages/api/v1/confirm.ts
@@ -147,6 +147,7 @@ export default async function handler(req: NextRequest) {
       );
     }
 
+    // Count previous messages in the conversation
     const countMessagesRes = await supabase
       .from("chat_messages")
       .select("*", { count: "exact", head: true })
@@ -162,12 +163,13 @@ export default async function handler(req: NextRequest) {
     );
 
     if (!requestData.confirm) {
+      // Cancel - user said this is incorrect!
       if (redis) await redis.json.del(requestData.conversation_id.toString());
       // Respond with a message from the assistant & add user cancel to GPT history
       const assistantMessage = {
         role: "assistant",
         content:
-          "Reasoning: I've cancelled the actions.\n\nTell user: What would you like me to do instead?",
+          "Tell user: I've cancelled this. What would you like me to do instead?",
       };
 
       const cancelRes = await supabase.from("chat_messages").insert([
@@ -274,11 +276,16 @@ export default async function handler(req: NextRequest) {
         const out = {
           role: "function",
           name: execute.action.name,
-          content: JSON.stringify(processAPIoutput(output, execute.action)),
+          content: JSON.stringify(
+            processAPIoutput(output, execute.action),
+            null,
+            2
+          ),
         } as ChatGPTMessage;
 
         console.log("out:", JSON.stringify(out));
 
+        // Add to DB to ensure state is consistent
         const funcRes = await supabase.from("chat_messages").insert({
           ...out,
           conversation_id: requestData.conversation_id,


### PR DESCRIPTION
Moving from `JSON.stringify(, null, 2)` -> `JSON.stringify()` in GPT messages since the indents cost a lot of tokens