### PR TITLE
Hide required enums with 1 value

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm test -- --runInBand --watchAll=false --bail --ci
+npm test -- --runInBand --watchAll=false --bail --ci --silent

--- a/__tests__/constructHttpRequest.test.ts
+++ b/__tests__/constructHttpRequest.test.ts
@@ -135,6 +135,38 @@ describe("constructHttpRequest", () => {
     });
     expect(requestOptions.body).toBe(undefined);
   });
+  it("GET - query param with required enum with 1 value", () => {
+    const { url, requestOptions } = constructHttpRequest({
+      action: {
+        ...constActionParams,
+        parameters: [
+          {
+            name: "param",
+            in: "query",
+            required: true,
+            schema: {
+              type: "integer",
+              enum: [1],
+            },
+          },
+        ],
+        path: "/api/mock/confirm",
+        request_method: "GET",
+        request_body_contents: null,
+      },
+      parameters: {},
+      organization,
+      userApiKey: "1234",
+      stream: () => {},
+    });
+    expect(url).toBe("https://api.mock/api/mock/confirm?param=1");
+    expect(requestOptions.method).toBe("GET");
+    expect(requestOptions.headers).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer 1234",
+    });
+    expect(requestOptions.body).toBe(undefined);
+  });
   it("GET - header param", () => {
     const { url, requestOptions } = constructHttpRequest({
       action: {
@@ -199,6 +231,42 @@ describe("constructHttpRequest", () => {
       Authorization: "Bearer 1234",
     });
     expect(requestOptions.body).toBe(JSON.stringify({ conversation_id: 1 }));
+  });
+  it("POST - body with required enum with 1 value", () => {
+    const { url, requestOptions } = constructHttpRequest({
+      action: {
+        ...constActionParams,
+        parameters: null,
+        path: "/api/mock/confirm",
+        request_method: "POST",
+        request_body_contents: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["user_id"],
+              properties: {
+                user_id: {
+                  type: "string",
+                  enum: ["1"],
+                },
+              },
+            },
+          },
+        },
+      },
+      parameters: {},
+      organization,
+      userApiKey: "1234",
+      stream: () => {},
+    });
+    expect(url).toBe("https://api.mock/api/mock/confirm");
+    expect(requestOptions.method).toBe("POST");
+    expect(requestOptions.headers).toEqual({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: "Bearer 1234",
+    });
+    expect(requestOptions.body).toBe(JSON.stringify({ user_id: "1" }));
   });
   it("POST - nested body", () => {
     const { url, requestOptions } = constructHttpRequest({

--- a/__tests__/prompts/getActionDescriptions.test.ts
+++ b/__tests__/prompts/getActionDescriptions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { getActionDescriptions } from "../../lib/prompts/chatBot";
+import {
+  formatReqBodySchema,
+  getActionDescriptions,
+} from "../../lib/prompts/chatBot";
 import { Action } from "../../lib/types";
 import {
   exampleRequestBody1,
@@ -140,6 +143,39 @@ describe("getActionDescriptions", () => {
       `1. action1: description1. PARAMETERS:
 - param1 (string): a description.
 - param2 (number): this isn't a description. REQUIRED
+`
+    );
+  });
+  it("param with enum with 1 option", () => {
+    const out = getActionDescriptions([
+      {
+        name: "action1",
+        description: "description1",
+        parameters: [
+          {
+            name: "param1",
+            in: "query",
+            required: true,
+            schema: {
+              type: "string",
+              enum: ["alpha"],
+            },
+          },
+          {
+            name: "param2",
+            in: "path",
+            description: "this isn't a description",
+            schema: {
+              type: "number",
+            },
+          },
+        ],
+        request_body_contents: {},
+      } as unknown as Action,
+    ]);
+    expect(out).toEqual(
+      `1. action1: description1. PARAMETERS:
+- param2 (number): this isn't a description.
 `
     );
   });
@@ -319,6 +355,41 @@ describe("getActionDescriptions", () => {
 - name (string): The name of the dashboard. REQUIRED
 - sharePermissions (object[]): The share permissions for the dashboard. REQUIRED
 \t- type ("user" | "group" | "project" | "projectRole" | "global" | "loggedin" | "authenticated" | "project-unknown"): user: Shared with a user. \`group\`: Shared with a group. \`project\` Shared with a project. \`projectRole\` Share with a project role in a project. \`global\` Shared globally. \`loggedin\` Shared with all logged-in users. \`project-unknown\` Shared with a project that the user does not have access to. REQUIRED
+`
+    );
+  });
+  it("exampleRequestBody with enum with 1 option", () => {
+    const out = getActionDescriptions([
+      {
+        name: "action1",
+        description: "description1",
+        parameters: [],
+        request_body_contents: {
+          "application/json": {
+            schema: {
+              required: ["enumProp"],
+              type: "object",
+              properties: {
+                description: {
+                  type: "string",
+                  description: "The description of the dashboard.",
+                },
+                enumProp: {
+                  type: "string",
+                  enum: ["option1"],
+                  description: "enum description",
+                },
+              },
+              additionalProperties: false,
+              description: "Details of a dashboard.",
+            },
+          },
+        },
+      } as unknown as Action,
+    ]);
+    expect(out).toEqual(
+      `1. action1: description1. PARAMETERS:
+- description (string): The description of the dashboard.
 `
     );
   });


### PR DESCRIPTION
Values which are required and must take a value in an enum, but there is only 1 possible value are cursed since they must be filled by the AI for absolutely no reason.

This removes them from the prompt and fills them in for the API request magically