### PR TITLE
Reduce how often we hit context limit

### DIFF
--- a/__tests__/lib/edge-runtime/removeOldestFunctionCalls.test.ts
+++ b/__tests__/lib/edge-runtime/removeOldestFunctionCalls.test.ts
@@ -1,0 +1,111 @@
+import { removeOldestFunctionCalls } from "../../../lib/edge-runtime/utils";
+import { ChatGPTMessage } from "../../../lib/models";
+
+const systemPrompt: ChatGPTMessage = {
+  role: "system",
+  content: "This is a system prompt.",
+};
+const userMessage: ChatGPTMessage = {
+  role: "user",
+  content: "This is a user message.",
+};
+const assistantMessage: ChatGPTMessage = {
+  role: "assistant",
+  content: "This is an assistant message.",
+};
+const replacementFunctionMessage: ChatGPTMessage = {
+  role: "function",
+  content: "Cut due to context limit",
+  name: "longFunctionCall",
+};
+function getLongFunctionCall(numTokens: number): ChatGPTMessage {
+  return {
+    role: "function",
+    content: new Array(numTokens + 1).join(" function"),
+    name: "longFunctionCall",
+  };
+}
+
+describe("removeOldestFunctionCalls", () => {
+  it("should leave unchanged - not over context limit", () => {
+    const out = removeOldestFunctionCalls([systemPrompt]);
+    expect(out).toEqual([systemPrompt]);
+  });
+  it("should remove 1 function call", () => {
+    const out = removeOldestFunctionCalls([
+      systemPrompt,
+      getLongFunctionCall(9000),
+    ]);
+    expect(out).toEqual([systemPrompt, replacementFunctionMessage]);
+  });
+  it("should remove function call, leaving user and assistant messages (start)", () => {
+    const out = removeOldestFunctionCalls([
+      systemPrompt,
+      getLongFunctionCall(9000),
+      userMessage,
+      assistantMessage,
+      userMessage,
+      assistantMessage,
+    ]);
+    expect(out).toEqual([
+      systemPrompt,
+      replacementFunctionMessage,
+      userMessage,
+      assistantMessage,
+      userMessage,
+      assistantMessage,
+    ]);
+  });
+  it("should remove function call, leaving user and assistant messages (end)", () => {
+    const out = removeOldestFunctionCalls([
+      systemPrompt,
+      userMessage,
+      assistantMessage,
+      userMessage,
+      assistantMessage,
+      getLongFunctionCall(9000),
+    ]);
+    expect(out).toEqual([
+      systemPrompt,
+      userMessage,
+      assistantMessage,
+      userMessage,
+      assistantMessage,
+      replacementFunctionMessage,
+    ]);
+  });
+  it("should remove 1 long call, leaving later short function call", () => {
+    const out = removeOldestFunctionCalls([
+      systemPrompt,
+      getLongFunctionCall(9000),
+      userMessage,
+      assistantMessage,
+      getLongFunctionCall(10),
+    ]);
+    expect(out).toEqual([
+      systemPrompt,
+      replacementFunctionMessage,
+      userMessage,
+      assistantMessage,
+      getLongFunctionCall(10),
+    ]);
+  });
+  it("should remove 1st of 2 long ones", () => {
+    const out = removeOldestFunctionCalls([
+      systemPrompt,
+      getLongFunctionCall(4500),
+      getLongFunctionCall(4500),
+      userMessage,
+      assistantMessage,
+      getLongFunctionCall(10),
+    ]);
+    expect(out).toEqual([
+      systemPrompt,
+      replacementFunctionMessage,
+      getLongFunctionCall(4500),
+      userMessage,
+      assistantMessage,
+      getLongFunctionCall(10),
+    ]);
+  });
+});

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -16,3 +16,5 @@ export const PRESETS = [
       "A set of actions for interacting with a customer analytics tool.",
   },
 ];
+
+export const MAX_TOKENS_OUT = 1000;

--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -1,6 +1,7 @@
 import { getTokenCount } from "../utils";
 import { ChatGPTMessage } from "../models";
 import { DBChatMessage } from "../types";
+import { MAX_TOKENS_OUT } from "../consts";
 
 export function DBChatMessageToGPT(message: DBChatMessage): ChatGPTMessage {
   if (message.role === "function") {
@@ -34,7 +35,7 @@ export function removeOldestFunctionCalls(
   const originalTokenCount = tokenCount;
   let numberRemoved = 0;
   // Keep removing until under the context limit
-  while (tokenCount >= 8192) {
+  while (tokenCount >= 8192 - MAX_TOKENS_OUT) {
     // Removes the oldest function call
     const oldestFunctionCallIndex = chatGptPrompt.findIndex(
       (m) => m.role === "function"

--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -38,7 +38,7 @@ export function removeOldestFunctionCalls(
   while (tokenCount >= 8192 - MAX_TOKENS_OUT) {
     // Removes the oldest function call
     const oldestFunctionCallIndex = chatGptPrompt.findIndex(
-      (m) => m.role === "function"
+      (m) => m.role === "function" && m.content !== "Cut due to context limit"
     );
     if (oldestFunctionCallIndex === -1) {
       // No function calls left to remove

--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -38,7 +38,8 @@ export function removeOldestFunctionCalls(
   while (tokenCount >= 8192 - MAX_TOKENS_OUT) {
     // Removes the oldest function call
     const oldestFunctionCallIndex = chatGptPrompt.findIndex(
-      (m) => m.role === "function" && m.content !== "Cut due to context limit"
+      // 204 since 4 tokens are added to the prompt for each message
+      (m) => m.role === "function" && getTokenCount([m]) >= 204
     );
     if (oldestFunctionCallIndex === -1) {
       // No function calls left to remove

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -116,10 +116,14 @@ export function openAiCost(
     costPerToken = 0.06 / 1000;
   }
 
-  const encoded = tokenizer.encodeChat(messages as ChatMessage[], "gpt-4");
-  const nTokens = encoded.length;
+  const nTokens = getTokenCount(messages);
   // For the 8k context model
   return nTokens * costPerToken;
+}
+
+export function getTokenCount(messages: ChatGPTMessage[]): number {
+  const encoded = tokenizer.encodeChat(messages as ChatMessage[], "gpt-4");
+  return encoded.length;
 }
 
 export function objectNotEmpty(obj: Object): boolean {

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -483,12 +483,13 @@ async function Angela( // Good ol' Angela
         org,
         language
       );
-      const promptInputCost = openAiCost(chatGptPrompt, "in");
-      console.log("GPT input cost:", promptInputCost);
-      totalCost += promptInputCost;
 
       // If over context limit, remove oldest function calls
       chatGptPrompt = removeOldestFunctionCalls([...chatGptPrompt]);
+
+      const promptInputCost = openAiCost(chatGptPrompt, "in");
+      console.log("GPT input cost:", promptInputCost);
+      totalCost += promptInputCost;
 
       const res = await exponentialRetryWrapper(
         streamOpenAIResponse,

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -3,7 +3,7 @@ import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { USAGE_LIMIT } from "../../../lib/consts";
+import { MAX_TOKENS_OUT, USAGE_LIMIT } from "../../../lib/consts";
 import {
   ActionToHttpRequest,
   ChatGPTMessage,
@@ -60,7 +60,7 @@ const AnswersZod = z.object({
 type AnswersType = z.infer<typeof AnswersZod>;
 
 const completionOptions: ChatGPTParams = {
-  max_tokens: 1000,
+  max_tokens: MAX_TOKENS_OUT,
 };
 
 if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
@@ -488,7 +488,7 @@ async function Angela( // Good ol' Angela
       totalCost += promptInputCost;
 
       // If over context limit, remove oldest function calls
-      chatGptPrompt = removeOldestFunctionCalls(chatGptPrompt);
+      chatGptPrompt = removeOldestFunctionCalls([...chatGptPrompt]);
 
       const res = await exponentialRetryWrapper(
         streamOpenAIResponse,


### PR DESCRIPTION
2 tactics have been employed here:
1. Remove any messages more than 20 messages ago in the chat history
2. Remove oldest function messages (tend to make up >80% of token count) when the context limit is close to being hit

The video below is really slow because the UI gets unresponsive when there's lots in the chat ([ticket for this here](https://learney.atlassian.net/browse/SF-2036))

https://github.com/Superflows-AI/superflows/assets/33871096/10ac59ec-0a31-4983-887b-afb4520a0a10

