### PR TITLE
Include examples in prompt

### DIFF
--- a/__tests__/prompts/getActionDescriptions.test.ts
+++ b/__tests__/prompts/getActionDescriptions.test.ts
@@ -393,4 +393,78 @@ describe("getActionDescriptions", () => {
 `
     );
   });
+  it("exampleRequestBody with examples", () => {
+    const out = getActionDescriptions([
+      {
+        name: "action1",
+        description: "description1",
+        parameters: [],
+        request_body_contents: {
+          "application/json": {
+            schema: {
+              required: ["enumProp"],
+              type: "object",
+              properties: {
+                created: {
+                  type: "string",
+                  description: "When it was created",
+                  example: "2021-01-01",
+                },
+                enumProp: {
+                  type: "string",
+                  enum: ["option1", "option2"],
+                  description: "enum description",
+                  example: "option2",
+                },
+              },
+              additionalProperties: false,
+              description: "Details of a dashboard.",
+            },
+          },
+        },
+      } as unknown as Action,
+    ]);
+    expect(out).toEqual(
+      `1. action1: description1. PARAMETERS:
+- created (string): When it was created. Example: 2021-01-01.
+- enumProp ("option1" | "option2"): enum description. REQUIRED
+`
+    );
+  });
+  it("params with examples", () => {
+    const out = getActionDescriptions([
+      {
+        name: "action1",
+        description: "description1",
+        parameters: [
+          {
+            name: "param1",
+            in: "query",
+            required: false,
+            description: "a description",
+            schema: {
+              type: "string",
+              example: "example1",
+            },
+          },
+          {
+            name: "updated",
+            in: "query",
+            required: false,
+            schema: {
+              type: "integer",
+            },
+            example: 1663734553,
+          },
+        ],
+        request_body_contents: null,
+      } as unknown as Action,
+    ]);
+    expect(out).toEqual(
+      `1. action1: description1. PARAMETERS:
+- param1 (string): a description. Example: example1.
+- updated (integer) Example: 1663734553.
+`
+    );
+  });
 });

--- a/lib/prompts/chatBot.ts
+++ b/lib/prompts/chatBot.ts
@@ -91,10 +91,15 @@ export function formatReqBodySchema(
       }`;
     }
   } else {
+    // TODO: Support object-level examples (if parent has example defined)
+    // Only show examples if there are no enums
+    // Note: using "Example:" rather than "E.g." because it's 1 fewer token
+    const example =
+      schema.example && !schema.enum ? ` Example: ${schema.example}.` : "";
     // Non-object, non-array
     paramString += `(${getType(schema.type, schema.enum)})${formatDescription(
       schema.description ?? schema.format
-    )}${isRequired ? " REQUIRED" : ""}`;
+    )}${example}${isRequired ? " REQUIRED" : ""}`;
   }
   return paramString;
 }
@@ -119,10 +124,19 @@ export function getActionDescriptions(actions: Action[]): string {
         // Below case is cursed: required param with 1 enum. Skip it.
         if (schema.enum && schema.enum.length === 1 && p.required) return;
 
+        // Only show examples if there are no enums
+        // Note: using "Example:" rather than "E.g." because it's 1 fewer token
+        const example =
+          (schema.example || p.example) && !schema.enum
+            ? ` Example: ${schema.example || p.example}.`
+            : "";
+
         paramString += `\n- ${p.name} (${getType(
           schema.type,
           schema.enum
-        )})${formatDescription(p.description)}${p.required ? " REQUIRED" : ""}`;
+        )})${formatDescription(p.description)}${example}${
+          p.required ? " REQUIRED" : ""
+        }`;
       });
     }
     const reqBody = action.request_body_contents as unknown as {


### PR DESCRIPTION
Some openapi specs skip descriptions and just have examples. We were ignoring examples previously.