### PR TITLE
Enable superset types of application json

### DIFF
--- a/__tests__/prompts/getActionDescriptions.test.ts
+++ b/__tests__/prompts/getActionDescriptions.test.ts
@@ -1,11 +1,67 @@
 import { describe, expect, it } from "@jest/globals";
-import { getActionDescriptions } from "../../lib/prompts/chatBot";
+import {
+  formatReqBodySchema,
+  getActionDescriptions,
+} from "../../lib/prompts/chatBot";
 import { Action } from "../../lib/types";
 import {
   exampleRequestBody1,
   exampleRequestBody2,
   exampleRequestBody3,
+  realWorldExampleSchema,
 } from "./testData";
+import { OpenAPIV3_1 } from "openapi-types";
+
+describe("formatReqBodySchema", () => {
+  it("real-world example", () => {
+    const out = formatReqBodySchema(
+      realWorldExampleSchema.schema as OpenAPIV3_1.SchemaObject
+    );
+    // TODO: There's a bug here. We shouldn't require an object if all
+    //  its children are enums with 1 value. We also probably want to
+    //  simplify the data.exchange object so it's less nested and complex.
+    //  It should probably be a top-level object instead, but this requires
+    //  changing how parameters are parsed from the GPT response.
+    expect(out).toEqual(`
+- workflow (object) REQUIRED
+- data (object) REQUIRED
+\t- exchange (object) REQUIRED
+\t\t- serviceProviderConfiguration (object)
+\t\t\t- sellSideProvider (string)
+\t\t\t- buySideProvider (string)
+\t\t\t- sellSideVirtualization ("enabled" | "disabled" | "not-applicable")
+\t\t\t- buySideVirtualization ("enabled" | "disabled" | "not-applicable")
+\t\t\t- sellSideSourceOfTruth ("if-core" | "baas-provider" | "card-processor")
+\t\t\t- buySideSourceOfTruth ("if-core" | "baas-provider" | "card-processor")
+\t\t- type ("spot" | "spot-debit-in-advance")
+\t\t- id (string): ID of exchange.
+\t\t- clientId (string): ID of client. REQUIRED
+\t\t- quoteId (string): ID of quote. REQUIRED
+\t\t- transactionNumber (string): Transaction number of exchange. REQUIRED
+\t\t- fixedSide ("buy" | "sell"): which side is fixed as amount. REQUIRED
+\t\t- rate (number): Rate. REQUIRED
+\t\t- serviceProviderRate (number): Service provider rate. REQUIRED
+\t\t- buyAccountId (string): ID of buy account. REQUIRED
+\t\t- buyCurrency (string): ISO 4217 currency code. REQUIRED
+\t\t- buyAmount (number): Buy amount of exchange. REQUIRED
+\t\t- serviceProviderBuyAmount (number): Buy amount of service provider. REQUIRED
+\t\t- sellAccountId (string): ID of sell account. REQUIRED
+\t\t- sellCurrency (string): ISO 4217 currency code. REQUIRED
+\t\t- sellAmount (number): Sell amount of exchange. REQUIRED
+\t\t- serviceProviderSellAmount (number): Sell amount of service provider. REQUIRED
+\t\t- feeAmount (number): Fee amount.
+\t\t- feeCurrency (string): Fee currency.
+\t\t- rollCount (integer): Roll count of exchange. REQUIRED
+\t\t- originalExchangeDate (string): Original exchange date. REQUIRED
+\t\t- exchangeDate (string): Calculated exchange date. REQUIRED
+\t\t- cutOffDateTime (string): Exchange cut-off date time. REQUIRED
+\t\t- settlementDate (string): Calculated exchange settlement date. REQUIRED
+\t\t- status ("pending" | "on-hold" | "completed" | "cancelled" | "failed"): Status of Exchange. REQUIRED
+\t\t- cancellationFee (number): Cancellation fee.
+- connect (object) REQUIRED
+- metadata (object) REQUIRED`);
+  });
+});
 
 describe("getActionDescriptions", () => {
   it("no parameters", () => {

--- a/__tests__/prompts/testData.ts
+++ b/__tests__/prompts/testData.ts
@@ -221,3 +221,249 @@ export const exampleRequestBody3 = {
     },
   },
 };
+
+export const realWorldExampleSchema = {
+  schema: {
+    required: ["connect", "data", "metadata", "workflow"],
+    type: "object",
+    properties: {
+      workflow: {
+        required: ["code"],
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description: "workflow code",
+            enum: ["client.direct.spot"],
+          },
+        },
+      },
+      data: {
+        required: ["exchange"],
+        type: "object",
+        properties: {
+          exchange: {
+            required: [
+              "buyAccountId",
+              "buyAmount",
+              "buyCurrency",
+              "clientId",
+              "cutOffDateTime",
+              "exchangeDate",
+              "fixedSide",
+              "originalExchangeDate",
+              "quoteId",
+              "rate",
+              "rollCount",
+              "sellAccountId",
+              "sellAmount",
+              "sellCurrency",
+              "serviceProviderBuyAmount",
+              "serviceProviderRate",
+              "serviceProviderSellAmount",
+              "settlementDate",
+              "status",
+              "transactionNumber",
+            ],
+            type: "object",
+            properties: {
+              serviceProviderConfiguration: {
+                type: "object",
+                properties: {
+                  sellSideProvider: {
+                    type: "string",
+                    enum: [
+                      "CLT",
+                      "DHB",
+                      "RLB",
+                      "FXR",
+                      "KCL",
+                      "CAB",
+                      "CLB",
+                      "TCC",
+                      "CCE",
+                      "NIU",
+                      "LHV",
+                      "GPS",
+                      "COA",
+                      "SUM",
+                      "UNC",
+                      "MOD",
+                    ],
+                  },
+                  buySideProvider: {
+                    type: "string",
+                    enum: [
+                      "CLT",
+                      "DHB",
+                      "RLB",
+                      "FXR",
+                      "KCL",
+                      "CAB",
+                      "CLB",
+                      "TCC",
+                      "CCE",
+                      "NIU",
+                      "LHV",
+                      "GPS",
+                      "COA",
+                      "SUM",
+                      "UNC",
+                      "MOD",
+                    ],
+                  },
+                  sellSideVirtualization: {
+                    type: "string",
+                    enum: ["enabled", "disabled", "not-applicable"],
+                  },
+                  buySideVirtualization: {
+                    type: "string",
+                    enum: ["enabled", "disabled", "not-applicable"],
+                  },
+                  sellSideSourceOfTruth: {
+                    type: "string",
+                    enum: ["if-core", "baas-provider", "card-processor"],
+                  },
+                  buySideSourceOfTruth: {
+                    type: "string",
+                    enum: ["if-core", "baas-provider", "card-processor"],
+                  },
+                },
+              },
+              type: { type: "string", enum: ["spot", "spot-debit-in-advance"] },
+              id: {
+                type: "string",
+                description: "ID of exchange",
+                format: "uuid",
+              },
+              clientId: {
+                type: "string",
+                description: "ID of client",
+                format: "uuid",
+              },
+              quoteId: {
+                type: "string",
+                description: "ID of quote",
+                format: "uuid",
+              },
+              transactionNumber: {
+                type: "string",
+                description: "Transaction number of exchange",
+              },
+              fixedSide: {
+                type: "string",
+                description: "which side is fixed as amount",
+                enum: ["buy", "sell"],
+              },
+              rate: { type: "number", description: "Rate" },
+              serviceProviderRate: {
+                type: "number",
+                description: "Service provider rate",
+              },
+              buyAccountId: {
+                type: "string",
+                description: "ID of buy account",
+                format: "uuid",
+              },
+              buyCurrency: {
+                maxLength: 3,
+                minLength: 3,
+                type: "string",
+                description: "ISO 4217 currency code",
+              },
+              buyAmount: {
+                type: "number",
+                description: "Buy amount of exchange",
+              },
+              serviceProviderBuyAmount: {
+                type: "number",
+                description: "Buy amount of service provider",
+              },
+              sellAccountId: {
+                type: "string",
+                description: "ID of sell account",
+                format: "uuid",
+              },
+              sellCurrency: {
+                maxLength: 3,
+                minLength: 3,
+                type: "string",
+                description: "ISO 4217 currency code",
+              },
+              sellAmount: {
+                type: "number",
+                description: "Sell amount of exchange",
+              },
+              serviceProviderSellAmount: {
+                type: "number",
+                description: "Sell amount of service provider",
+              },
+              feeAmount: { type: "number", description: "Fee amount" },
+              feeCurrency: { type: "string", description: "Fee currency" },
+              rollCount: {
+                type: "integer",
+                description: "Roll count of exchange",
+                format: "int32",
+              },
+              originalExchangeDate: {
+                type: "string",
+                description: "Original exchange date",
+                format: "date",
+              },
+              exchangeDate: {
+                type: "string",
+                description: "Calculated exchange date",
+                format: "date",
+              },
+              cutOffDateTime: {
+                type: "string",
+                description: "Exchange cut-off date time",
+                format: "date-time",
+              },
+              settlementDate: {
+                type: "string",
+                description: "Calculated exchange settlement date",
+                format: "date",
+              },
+              status: {
+                type: "string",
+                description: "Status of Exchange",
+                enum: [
+                  "pending",
+                  "on-hold",
+                  "completed",
+                  "cancelled",
+                  "failed",
+                ],
+              },
+              cancellationFee: {
+                type: "number",
+                description: "Cancellation fee",
+                nullable: true,
+              },
+            },
+            description: "exchange data model",
+            readOnly: false,
+          },
+        },
+      },
+      connect: {
+        required: ["serviceProvider", "type"],
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            description: "service provider selection type",
+            enum: ["explicit"],
+          },
+          serviceProvider: {
+            type: "string",
+            description: "account is connected to this service provider ",
+            enum: ["railsbank"],
+          },
+        },
+      },
+      metadata: { type: "object" },
+    },
+  },
+};

--- a/lib/edge-runtime/utils.ts
+++ b/lib/edge-runtime/utils.ts
@@ -62,3 +62,18 @@ export function removeOldestFunctionCalls(
   );
   return chatGptPrompt;
 }
+
+export function getJsonMIMEType<inObj>(
+  inputDict: Record<string, inObj> | undefined | null
+): inObj | undefined {
+  if (!inputDict) return undefined;
+  if ("application/json" in inputDict) {
+    return inputDict["application/json"];
+  } else if ("*/*" in inputDict) {
+    return inputDict["*/*"];
+  } else if ("*/json" in inputDict) {
+    return inputDict["*/*"];
+  } else {
+    return undefined;
+  }
+}

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -11,7 +11,7 @@ export function parseGPTStreamedData(
       })
       .filter((l: string) => l);
   } catch (e) {
-    console.warn(
+    console.log(
       `Error parsing GPT output string: ${gptOutString}. Error: ${e}`
     );
     return undefined;

--- a/pages/api/mock/[...slug].ts
+++ b/pages/api/mock/[...slug].ts
@@ -19,6 +19,7 @@ import {
   splitPath,
   chunksToProperties,
 } from "../../../lib/utils";
+import { getJsonMIMEType } from "../../../lib/edge-runtime/utils";
 
 if (process.env.SERVICE_LEVEL_KEY_SUPABASE === undefined) {
   throw new Error("SERVICE_LEVEL_KEY_SUPABASE is not defined!");
@@ -192,7 +193,7 @@ export default async function handler(
 
   let responseCode;
   // Search for a 2xx response starting at 200
-  const response =
+  const response: OpenAPIV3_1.ResponseObject =
     matchingAction && matchingAction.responses
       ? ((responseCode = Object.keys(matchingAction.responses).find(
           (key) => Number(key) >= 200 && Number(key) < 300
@@ -240,8 +241,8 @@ export default async function handler(
 
   // Hierarchy of fallbacks if we don't have full schema etc
   const fallback =
-    response.content?.["application/json"]?.schema ||
-    response.content?.["application/json"] ||
+    getJsonMIMEType(response.content)?.schema ||
+    getJsonMIMEType(response.content) ||
     response.content ||
     response;
 


### PR DESCRIPTION
For example, `*/*` is a valid MIME type that occurs in OpenAPI specs, but isn't supported by us