### PR TITLE
Support trailing slashes in hostnames

### DIFF
--- a/lib/edge-runtime/requests.ts
+++ b/lib/edge-runtime/requests.ts
@@ -69,7 +69,12 @@ export function constructHttpRequest({
     requestOptions.body = JSON.stringify(body);
   }
 
-  let url = action.api_host + action.path;
+  // Below URL(...).href deals with "/" between the path and host
+  let url = new URL(action.path, action.api_host).href
+    // These are because path parameters can be in action.path e.g. /{param}
+    // and above line encodes them into %7B and %7D
+    .replaceAll("%7B", "{")
+    .replaceAll("%7D", "}");
 
   // TODO: accept array for JSON?
   // Set parameters


### PR DESCRIPTION
Previously it was possible to get errors due to a path like: `https://superflows.ai/` and actions like `/api/endpoint` because it'd try to call `https://superflows.ai//api/endpoint` (double `/`).

This fixes that