### PR TITLE
Fix streaming base64 images data bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@supabase/auth-ui-react": "^0.4.2",
         "@supabase/auth-ui-shared": "^0.1.6",
         "@supabase/supabase-js": "^2.26.0",
-        "@superflows/chat-ui-react": "^1.1.21",
+        "@superflows/chat-ui-react": "^1.2.0",
         "@tailwindcss/forms": "^0.5.3",
         "@types/jest": "^29.5.3",
         "@uppy/core": "^3.2.1",
@@ -2078,9 +2078,9 @@
       }
     },
     "node_modules/@superflows/chat-ui-react": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@superflows/chat-ui-react/-/chat-ui-react-1.1.21.tgz",
-      "integrity": "sha512-aVvq7QOkJv1i9ki0z3RgZAbkeyK82cdDC7qB+DOD2wKqr04JNvA41oPuUKpbOn2spiE/cbs8DbMh2Iy2WkhiBA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@superflows/chat-ui-react/-/chat-ui-react-1.2.0.tgz",
+      "integrity": "sha512-wgbO4RBp3uQ9N7eAQs6YxvH+dK1AFBLqPrwtFG3ZJA8yzoOxFy633sN/9Q+4KNmeJiBgl1CD6Pv3EyKHFcsx0g==",
       "dependencies": {
         "@headlessui/react": "1.4",
         "@heroicons/react": "^2.0.18",
@@ -7789,9 +7789,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.1.tgz",
-      "integrity": "sha512-2USspxOCXWGIKHwuQ9XElxPPYrDOJHDQ5DQ870CoD+CxJbBnRDIBCfhioUJJjct7BKOy80Ia8cVstIcIMb/0+Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@supabase/auth-ui-react": "^0.4.2",
     "@supabase/auth-ui-shared": "^0.1.6",
     "@supabase/supabase-js": "^2.26.0",
-    "@superflows/chat-ui-react": "^1.1.21",
+    "@superflows/chat-ui-react": "^1.2.0",
     "@tailwindcss/forms": "^0.5.3",
     "@types/jest": "^29.5.3",
     "@uppy/core": "^3.2.1",

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -443,7 +443,7 @@ async function Angela( // Good ol' Angela
   function streamInfo(step: StreamingStepInput) {
     controller.enqueue(
       encoder.encode(
-        "data:" +
+        "data: " +
           JSON.stringify({
             id: conversationId,
             ...step,
@@ -632,8 +632,7 @@ async function Angela( // Good ol' Angela
               const outMessage: GPTMessageInclSummary = {
                 role: "function",
                 name: command.name,
-                content:
-                  typeof out === "string" ? out : JSON.stringify(out, null, 2),
+                content: typeof out === "string" ? out : JSON.stringify(out),
               };
 
               // If >500 tokens, summarise the message


### PR DESCRIPTION
Base64 image strings have `data:` in them, which we were previously using as a spacer for chunks.

Have changed to using `data: ` (with a space at the end) so this clash doesn't occur