### PR TITLE
Replace redacted ids and urls when streaming

### DIFF
--- a/__tests__/api/replaceVariablesDuringStreaming.test.ts
+++ b/__tests__/api/replaceVariablesDuringStreaming.test.ts
@@ -45,6 +45,13 @@ describe("replaceVariablesDuringStreaming", () => {
     expect(out.content).toEqual("URL2 ");
     expect(out.valueVariableBuffer).toEqual("");
   });
+  it("variable in 1 chunk, match", () => {
+    const out = replaceVariablesDuringStreaming("content=URL1 ", "", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("content=https://google.com ");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
   it("URL variable, buffer filled, match", () => {
     const out = replaceVariablesDuringStreaming("1 ", "URL", {
       URL1: "https://google.com",

--- a/__tests__/api/replaceVariablesDuringStreaming.test.ts
+++ b/__tests__/api/replaceVariablesDuringStreaming.test.ts
@@ -1,0 +1,63 @@
+import { replaceVariablesDuringStreaming } from "../../pages/api/v1/answers";
+
+describe("replaceVariablesDuringStreaming", () => {
+  it("no variables", () => {
+    const out = replaceVariablesDuringStreaming(
+      "This is a test string",
+      "",
+      {},
+    );
+    expect(out.content).toEqual("This is a test string");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("variable, but none in string", () => {
+    const out = replaceVariablesDuringStreaming("This is a test string", "", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("This is a test string");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("ID in string, but not at the end", () => {
+    const out = replaceVariablesDuringStreaming("ID ", "", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("ID ");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("variable, ID included", () => {
+    const out = replaceVariablesDuringStreaming("ID", "", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("");
+    expect(out.valueVariableBuffer).toEqual("ID");
+  });
+  it("variable, buffer filled, no match", () => {
+    const out = replaceVariablesDuringStreaming(" baby", "URL", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("URL baby");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("variable, matches format, no match", () => {
+    const out = replaceVariablesDuringStreaming("2 ", "URL", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("URL2 ");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("URL variable, buffer filled, match", () => {
+    const out = replaceVariablesDuringStreaming("1 ", "URL", {
+      URL1: "https://google.com",
+    });
+    expect(out.content).toEqual("https://google.com ");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+  it("ID variable, buffer filled, match", () => {
+    const out = replaceVariablesDuringStreaming("2 ", "ID", {
+      ID1: "ff3a5-3f3a5-3f3a5-3f3a5",
+      ID2: "ff3a5-3f3a5-3f3a5-77877",
+    });
+    expect(out.content).toEqual("ff3a5-3f3a5-3f3a5-77877 ");
+    expect(out.valueVariableBuffer).toEqual("");
+  });
+});

--- a/__tests__/api/streamResponseToUser.test.ts
+++ b/__tests__/api/streamResponseToUser.test.ts
@@ -1,0 +1,51 @@
+import { streamResponseToUser } from "../../pages/api/v1/answers";
+import { Readable } from "stream";
+
+describe("streamResponseToUser", () => {
+  it("very simple", async () => {
+    const mockReadable = new Readable();
+    mockReadable.push('data: {"choices": [{"delta": {"content": "hello"}}]}');
+    mockReadable.push(null);
+
+    const uint8array = new TextEncoder().encode(mockReadable.read());
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(uint8array);
+        controller.close();
+      },
+    });
+    const mockFn = jest.fn();
+    // @ts-ignore
+    const out = await streamResponseToUser(mockStream, mockFn, {});
+    expect(out).toEqual("hello");
+    expect(mockFn).toBeCalledWith({ role: "assistant", content: "hello" });
+  });
+  it("replace ID1 with id value correctly", async () => {
+    const mockReadable = new Readable();
+    mockReadable.push(
+      'data: {"choices": [{"delta": {"content": "The id is"}}]}',
+    );
+    mockReadable.push('data: {"choices": [{"delta": {"content": " ID"}}]}');
+    mockReadable.push('data: {"choices": [{"delta": {"content": "1"}}]}');
+    mockReadable.push(null); // end the stream
+
+    const uint8array = new TextEncoder().encode(mockReadable.read());
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(uint8array);
+        controller.close();
+      },
+    });
+    const mockFn = jest.fn();
+    // @ts-ignore
+    const out = await streamResponseToUser(mockStream, mockFn, {
+      ID1: "53fa4-3f3f3-3f3f3-3f3f3-3f3f3",
+    });
+    expect(out).toEqual("The id is ID1");
+    expect(mockFn).toBeCalledWith({ role: "assistant", content: "The id is" });
+    expect(mockFn).toBeCalledWith({
+      role: "assistant",
+      content: " 53fa4-3f3f3-3f3f3-3f3f3-3f3f3",
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "2.8.0",
         "pretty-quick": "^3.1.3",
+        "stream": "^0.0.2",
         "tailwindcss": "^3.2.4",
         "typescript": "4.9.4"
       }
@@ -4577,6 +4578,12 @@
       "version": "1.4.523",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
       "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
+      "dev": true
+    },
+    "node_modules/emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -11220,6 +11227,15 @@
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
+      "dev": true,
+      "dependencies": {
+        "emitter-component": "^1.1.1"
       }
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "prettier": "2.8.0",
     "pretty-quick": "^3.1.3",
+    "stream": "^0.0.2",
     "tailwindcss": "^3.2.4",
     "typescript": "4.9.4"
   }

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -776,7 +776,7 @@ async function storeActionsAwaitingConfirmation(
 export async function streamResponseToUser(
   res: ReadableStream,
   streamInfo: (step: StreamingStepInput) => void,
-  valueVariableMap: Record<string, string>,
+  valueVariableMap?: Record<string, string>,
 ): Promise<string> {
   const decoder = new TextDecoder();
   const reader = res.getReader();
@@ -809,11 +809,13 @@ export async function streamResponseToUser(
       rawOutput += content;
       // What streams back to the user has the variables replaced with their real values
       //  so URL1 is replaced by the actual URL
-      ({ content, valueVariableBuffer } = replaceVariablesDuringStreaming(
-        content,
-        valueVariableBuffer,
-        valueVariableMap,
-      ));
+      if (valueVariableMap) {
+        ({ content, valueVariableBuffer } = replaceVariablesDuringStreaming(
+          content,
+          valueVariableBuffer,
+          valueVariableMap,
+        ));
+      }
 
       if (content) streamInfo({ role: "assistant", content });
     }


### PR DESCRIPTION
Fixes below problem (giving a URL as URL variable in text output)
![Screenshot from 2023-10-02 13-52-31](https://github.com/Superflows-AI/superflows/assets/33871096/047f6abf-970a-4a6c-a62d-6f2dd33faf08)
