### PR TITLE
Allow use of API_SUPABASE_URL env var for docker self-hosting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,6 @@
   "extends": "next/core-web-vitals",
     "rules": {
         "@next/next/no-html-link-for-pages": "off"
-    }
+    },
+  "ignorePatterns": ["docker/development/supabase"]
 }

--- a/pages/api/create-org.ts
+++ b/pages/api/create-org.ts
@@ -15,7 +15,7 @@ if (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === undefined) {
 }
 
 const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
   process.env.SERVICE_LEVEL_KEY_SUPABASE ?? "",
 );
 

--- a/pages/api/join-org.ts
+++ b/pages/api/join-org.ts
@@ -13,7 +13,7 @@ if (process.env.NEXT_PUBLIC_SUPABASE_URL === undefined) {
 }
 
 const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SERVICE_LEVEL_KEY_SUPABASE,
 );
 

--- a/pages/api/mock/[...slug].ts
+++ b/pages/api/mock/[...slug].ts
@@ -129,7 +129,7 @@ const supabase = createClient(
   // Bring me my arrows of desire:
   process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
   // Bring me my Spear: O clouds unfold!
-  process.env.SERVICE_LEVEL_KEY_SUPABASE ?? "",
+  process.env.API_SUPABASE_URL ?? process.env.SERVICE_LEVEL_KEY_SUPABASE ?? "",
   // Bring me my Chariot of fire!
 );
 

--- a/pages/api/swagger-to-actions.ts
+++ b/pages/api/swagger-to-actions.ts
@@ -15,7 +15,7 @@ if (process.env.NEXT_PUBLIC_SUPABASE_URL === undefined) {
 }
 
 const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SERVICE_LEVEL_KEY_SUPABASE!,
 );
 

--- a/pages/api/team.ts
+++ b/pages/api/team.ts
@@ -20,7 +20,7 @@ if (!process.env.SERVICE_LEVEL_KEY_SUPABASE) {
 // Bring me my Bow of burning gold:
 const supabase = createClient<Database>(
   // Bring me my arrows of desire:
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
   // Bring me my Spear: O clouds unfold!
   process.env.SERVICE_LEVEL_KEY_SUPABASE,
   // Bring me my Chariot of fire!

--- a/pages/api/v1/answers.ts
+++ b/pages/api/v1/answers.ts
@@ -67,7 +67,7 @@ if (
 // Bring me my Bow of burning gold:
 const supabase = createClient<Database>(
   // Bring me my arrows of desire:
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
   // Bring me my Spear: O clouds unfold!
   process.env.SERVICE_LEVEL_KEY_SUPABASE,
   // Bring me my Chariot of fire!

--- a/pages/api/v1/confirm.ts
+++ b/pages/api/v1/confirm.ts
@@ -57,7 +57,7 @@ if (
 }
 
 const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
   process.env.SERVICE_LEVEL_KEY_SUPABASE ?? "",
 );
 

--- a/pages/api/v1/feedback.ts
+++ b/pages/api/v1/feedback.ts
@@ -37,7 +37,7 @@ if (!process.env.SERVICE_LEVEL_KEY_SUPABASE) {
 // Bring me my Bow of burning gold:
 const supabase = createClient<Database>(
   // Bring me my arrows of desire:
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.API_SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
   // Bring me my Spear: O clouds unfold!
   process.env.SERVICE_LEVEL_KEY_SUPABASE,
   // Bring me my Chariot of fire!


### PR DESCRIPTION
These are on backend usages and not frontend because when deployed in docker, backend is running in a docker container, so localhost doesn't mean what it does client-side (the `NEXT_PUBLIC_SUPABASE_URL` env var is used both client-side and in the API). So we need a different supabase url client side and backend side