### PR TITLE
big improvement on action filtering

### DIFF
--- a/lib/edge-runtime/filterActions.ts
+++ b/lib/edge-runtime/filterActions.ts
@@ -57,7 +57,7 @@ export async function getRelevantActions(
 
   const response = await exponentialRetryWrapper(
     getLLMResponse,
-    [prompt, { temperature: 0.7 }, model],
+    [prompt, { temperature: 0 }, model],
     3,
   );
 

--- a/lib/prompts/actionFiltering.ts
+++ b/lib/prompts/actionFiltering.ts
@@ -11,28 +11,21 @@ export function actionFilteringPrompt(
   return [
     {
       role: "system",
-      content: `You are an AI with the ability to call functions, you must determine the correct function based on the user's request. 
-      
-The functions you have access to are described below. 
+      content: `Below are ${actions.length} functions.
 
 The functions are formatted with {{NAME}}: {{DESCRIPTION}}. PARAMETERS: {{PARAMETERS}}. Each parameter is formatted like: "- {{NAME}} ({{DATATYPE}}: [{{POSSIBLE_VALUES}}]): {{DESCRIPTION}}. {{"REQUIRED" if parameter required}}"
 
-FUNCTIONS START
-
 ${numberedActions}
-
-FUNCTIONS END 
 
 You have three options for each function: 
 
-1. Relevant: Use this if you are certain that the user's request pertains to this function.
-2. Not Sure: Use this if the user's request could possibly pertain to this function, but you aren't certain.
-3. Irrelevant: Use this if you are certain that the user's request does not pertain to this function.
+1. Relevant: The function is relevant to the user's request 
+2. Not Sure: You are not 100% sure, or you do not know what the function does
+3. Irrelevant: You are 100% certain the function has 0 relevance to the user's request
 
-If the user's request is unclear, it's better to mark all functions as 'Not Sure' rather than risk making incorrect assumptions.
+Mark functions as 'Not Sure' instead of Irrelevant if you are not 100% sure. This is very important do not forget this.
 
 Every line of your response must be in the following format:
-
 {function_name}: Relevant | Irrelevant | Not sure.
 
 Your response must be exactly ${actions.length} lines, one line for each function.`,


### PR DESCRIPTION
This new version was tested on the actions of Ontik (company house) and the Carbon Interface demo. A training dataset was generated by manually marking relevant actions across a number of realistic user queries. Then the response from the AI was compared to this dataset. This was repeated 3 times for each query.

results here: https://docs.google.com/spreadsheets/d/16ZuyxaViuMKMLtHo_jpmim4Ez4qx81LA6H3Uw8pff-c/edit?usp=sharing

In summary, the prompt here made 0 "misses" (when a relevant action is marked as irrelevant) across both datasets.
84% of irrelevant actions were marked as irrelevant in the carbon interface dataset and 60% of irrelevant actions in the Ontik dataset. 







 